### PR TITLE
Change request buffering in stackdriver sink to be explicit and order…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ ifndef TEMP_DIR
 TEMP_DIR:=$(shell mktemp -d /tmp/heapster.XXXXXX)
 endif
 
-VERSION?=v2.0.0
+# This version is used as a tag for development images only.
+VERSION?=dev
 GIT_COMMIT:=$(shell git rev-parse --short HEAD)
 
 ifdef REPO_DIR


### PR DESCRIPTION
…ed, rather than random. This should prevent dropping time series due to out-of-order writes.

/assign @kawych

